### PR TITLE
Font property shorthand parsing

### DIFF
--- a/lib/aggregates.js
+++ b/lib/aggregates.js
@@ -22,4 +22,3 @@ module.exports = function(obj) {
   return result;
 
 };
-

--- a/lib/declarations.js
+++ b/lib/declarations.js
@@ -2,6 +2,9 @@
 var camelCase = require('camelcase');
 var isVendorPrefixed = require('is-vendor-prefixed');
 
+var fontShorthand = require('./util/font-shorthand');
+var uniqueDeclarations = require('./util/unique-declarations')
+
 module.exports = function(obj) {
 
   var index = 0;
@@ -18,7 +21,6 @@ module.exports = function(obj) {
     rule.eachDecl(function(declaration) {
       if (declaration.prop) {
         var propKey = camelCase(declaration.prop);
-        var isDupe = false;
 
         if (isVendorPrefixed(declaration.prop)) {
           result.vendorPrefixCount++;
@@ -31,20 +33,11 @@ module.exports = function(obj) {
         delete declaration.source;
         delete declaration.before;
         delete declaration.between;
+
         declaration.index = index;
         result.all.push(declaration);
-        if (!result.byProperty[propKey]) {
-          result.byProperty[propKey] = [];
-          result.unique[propKey] = [];
-        }
-        result.byProperty[propKey].forEach(function(d, i) {
-          if (result.all[d.index].value == declaration.value) {
-            isDupe = true;
-          }
-        });
-        if (!isDupe) {
-          result.unique[propKey].push(declaration);
-        }
+
+        result.byProperty[propKey] = result.byProperty[propKey] || [];
         result.byProperty[propKey].push(declaration);
         index++;
       }
@@ -57,12 +50,16 @@ module.exports = function(obj) {
     if (!result.byMedia[key]) {
       result.byMedia[key] = [];
     }
+
     atRule.eachRule(function(rule) {
       rule.eachDecl(function(declaration) {
         result.byMedia[key].push(declaration);
       });
     });
   });
+
+  fontShorthand(result);
+  result.unique = uniqueDeclarations(result);
 
   return result;
 

--- a/lib/util/font-shorthand.js
+++ b/lib/util/font-shorthand.js
@@ -1,0 +1,90 @@
+var cssFontParser = require('cssfontparser');
+
+module.exports = function handleFontShorthand(obj) {
+  if (obj.byProperty.font) {
+    obj.byProperty.font.forEach(function(fontShorthand) {
+      var fontProperties = cssFontParser(fontShorthand.value);
+
+      if (fontProperties.style) {
+        obj.byProperty.fontStyle = obj.byProperty.fontStyle || [];
+
+        obj.byProperty.fontStyle.push(
+          generateDeclaration(
+            'font-style',
+            fontProperties.style,
+            fontShorthand.index
+          )
+        );
+      }
+
+      if (fontProperties.variant) {
+        obj.byProperty.fontVariant = obj.byProperty.fontVariant || [];
+
+        obj.byProperty.fontVariant.push(
+          generateDeclaration(
+            'font-variant',
+            fontProperties.variant,
+            fontShorthand.index
+          )
+        );
+      }
+
+      if (fontProperties.weight) {
+        obj.byProperty.fontWeight = obj.byProperty.fontWeight || [];
+
+        obj.byProperty.fontWeight.push(
+          generateDeclaration(
+            'font-weight',
+            fontProperties.weight,
+            fontShorthand.index
+          )
+        );
+      }
+
+      if (fontProperties.size) {
+        obj.byProperty.fontSize = obj.byProperty.fontSize || [];
+
+        obj.byProperty.fontSize.push(
+          generateDeclaration(
+            'font-size',
+            fontProperties.size,
+            fontShorthand.index
+          )
+        );
+      }
+
+      if (fontProperties.lineHeight) {
+        obj.byProperty.lineHeight = obj.byProperty.lineHeight || [];
+
+        obj.byProperty.lineHeight.push(
+          generateDeclaration(
+            'line-height',
+            fontProperties.lineHeight,
+            fontShorthand.index
+          )
+        );
+      }
+
+      if (fontProperties.family) {
+        obj.byProperty.fontFamily = obj.byProperty.fontFamily || [];
+
+        obj.byProperty.fontFamily.push(
+          generateDeclaration(
+            'font-family',
+            fontProperties.family.join(', '),
+            fontShorthand.index
+          )
+        );
+      }
+    });
+  }
+}
+
+function generateDeclaration(prop, value, index) {
+  return {
+    type: 'decl',
+    prop: prop,
+    value: value,
+    index: index
+  };
+}

--- a/lib/util/unique-declarations.js
+++ b/lib/util/unique-declarations.js
@@ -1,0 +1,11 @@
+var _uniq = require('lodash').uniq;
+
+module.exports = function uniqueDeclarations(obj) {
+  uniqueDecls = {};
+
+  Object.keys(obj.byProperty).forEach(function(propKey){
+    uniqueDecls[propKey] = _uniq(obj.byProperty[propKey], 'value');
+  });
+
+  return uniqueDecls;
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   "dependencies": {
     "camelcase": "^1.0.2",
     "commander": "^2.5.0",
+    "cssfontparser": "^1.1.0",
     "gzip-size": "^1.0.0",
     "is-vendor-prefixed": "0.0.1",
+    "lodash": "^3.0.0",
     "postcss": "^3.0.7",
     "specificity": "^0.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssstats",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "High-level stats for stylesheets",
   "main": "index.js",
   "author": "Brent Jackson",

--- a/test/fixtures/font-shorthand.css
+++ b/test/fixtures/font-shorthand.css
@@ -3,5 +3,5 @@
 }
 
 .b {
-  font: bold 20px/1.5 Times, serif;
+  font: italic bold 20px/1.5 Times, serif;
 }

--- a/test/fixtures/font-shorthand.css
+++ b/test/fixtures/font-shorthand.css
@@ -1,0 +1,7 @@
+.a {
+  font-size: 10px;
+}
+
+.b {
+  font: bold 20px/1.5 Times, serif;
+}

--- a/test/results/font-awesome.json
+++ b/test/results/font-awesome.json
@@ -25121,6 +25121,12 @@
           "prop": "font-size",
           "value": "2em",
           "index": 74
+        },
+        {
+          "type": "decl",
+          "prop": "font-size",
+          "value": 14,
+          "index": 1
         }
       ],
       "textRendering": [
@@ -28446,6 +28452,14 @@
           "value": "\"\\f20c\"",
           "index": 554
         }
+      ],
+      "fontFamily": [
+        {
+          "type": "decl",
+          "prop": "font-family",
+          "value": "FontAwesome",
+          "index": 1
+        }
       ]
     },
     "unique": {
@@ -28501,6 +28515,12 @@
           "prop": "font-size",
           "value": "5em",
           "index": 12
+        },
+        {
+          "type": "decl",
+          "prop": "font-size",
+          "value": 14,
+          "index": 1
         }
       ],
       "textRendering": [
@@ -31778,6 +31798,14 @@
           "value": "\"\\f20c\"",
           "index": 554
         }
+      ],
+      "fontFamily": [
+        {
+          "type": "decl",
+          "prop": "font-family",
+          "value": "FontAwesome",
+          "index": 1
+        }
       ]
     },
     "byMedia": {},
@@ -31817,7 +31845,8 @@
       "msTransform",
       "height",
       "color",
-      "content"
+      "content",
+      "fontFamily"
     ],
     "mediaQueries": [],
     "display": {
@@ -31829,8 +31858,8 @@
       "unique": 1
     },
     "fontSize": {
-      "total": 7,
-      "unique": 6
+      "total": 8,
+      "unique": 7
     },
     "textRendering": {
       "total": 1,
@@ -31939,6 +31968,10 @@
     "content": {
       "total": 479,
       "unique": 479
+    },
+    "fontFamily": {
+      "total": 1,
+      "unique": 1
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,14 @@ describe('font shorthand property', function() {
   it('should be able to grab the font-family declaration', function() {
     assert.equal(stats.aggregates.fontFamily.total, 1);
   });
+
+  it('should be able to grab the font-weight declaration', function() {
+    assert.equal(stats.aggregates.fontWeight.total, 1);
+  });
+
+  it('should be able to grab the font-style declaration', function() {
+    assert.equal(stats.aggregates.fontStyle.total, 1);
+  });
 });
 
 function fixture(name) {

--- a/test/test.js
+++ b/test/test.js
@@ -73,6 +73,22 @@ describe('css-statistics', function() {
   });
 });
 
+describe('font shorthand property', function() {
+  var stats;
+
+  before(function() {
+    stats = cssstats(fixture('font-shorthand'));
+  });
+
+  it('should be able to grab the font-size declaration', function() {
+    assert.equal(stats.aggregates.fontSize.total, 2);
+  });
+
+  it('should be able to grab the font-family declaration', function() {
+    assert.equal(stats.aggregates.fontFamily.total, 1);
+  });
+});
+
 function fixture(name) {
   return fs.readFileSync('test/fixtures/' + name + '.css', 'utf8').toString().trim();
 }


### PR DESCRIPTION
Here's the failing test for the font shorthand properties not being aggregated.

`font` docs: <https://developer.mozilla.org/en-US/docs/Web/CSS/font>

Luckily, I found a package that parses said shorthand property, so I will now work on getting the tests to pass: https://www.npmjs.com/package/cssfontparser

Related to: mrmrs/cssstats#109