### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+
+node_js:
+  - 0.10
+  - 0.11


### PR DESCRIPTION
This way, we can automatically run the unit tests for all commits and PRs. In
order to turn travis on, you will need to visit travis-ci.org and turn it
on for this repository (whenever you get the time, no rush).