### PR TITLE
Handle errors with the CSS font parser

### DIFF
--- a/lib/util/font-shorthand.js
+++ b/lib/util/font-shorthand.js
@@ -5,6 +5,10 @@ module.exports = function handleFontShorthand(obj) {
     obj.byProperty.font.forEach(function(fontShorthand) {
       var fontProperties = cssFontParser(fontShorthand.value);
 
+      if (!fontProperties) {
+        return;
+      }
+
       if (fontProperties.style) {
         obj.byProperty.fontStyle = obj.byProperty.fontStyle || [];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssstats",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "High-level stats for stylesheets",
   "main": "index.js",
   "author": "Brent Jackson",


### PR DESCRIPTION
When out in the wild, it appears that the cssfontparser library is
having a hard time dealing with a lot of uses of the font shorthand.
As such, I've added a short circuit for when the parsing returns
'undefined'.